### PR TITLE
Improved AWS decorators.

### DIFF
--- a/src/ThrowableDiagnostic/Aws/Decorator.php
+++ b/src/ThrowableDiagnostic/Aws/Decorator.php
@@ -17,7 +17,10 @@ final class Decorator implements DecoratorInterface
     public function diagnose(Throwable $throwable): ThrowableDiagnosticInterface
     {
         if ($throwable instanceof AwsException) {
-            $transient = $this->isAwsErrorCodeTransient($throwable->getAwsErrorCode());
+            $transient = $throwable->isConnectionError();
+            if (!$transient && $throwable->getAwsErrorCode()) {
+                $transient = $this->isAwsErrorCodeTransient($throwable->getAwsErrorCode());
+            }
             throw $this->getDiagnosedFactory()
                 ->create()
                 ->setTransient($transient)

--- a/src/ThrowableDiagnostic/Aws/S3Decorator.php
+++ b/src/ThrowableDiagnostic/Aws/S3Decorator.php
@@ -17,7 +17,10 @@ final class S3Decorator implements S3DecoratorInterface
     public function diagnose(Throwable $throwable): ThrowableDiagnosticInterface
     {
         if ($throwable instanceof S3Exception) {
-            $transient = $this->isAwsErrorCodeTransient($throwable->getAwsErrorCode());
+            $transient = $throwable->isConnectionError();
+            if (!$transient && $throwable->getAwsErrorCode()) {
+                $transient = $this->isAwsErrorCodeTransient($throwable->getAwsErrorCode());
+            }
             throw $this->getDiagnosedFactory()
                 ->create()
                 ->setTransient($transient)

--- a/src/ThrowableDiagnostic/Aws/SnsDecorator.php
+++ b/src/ThrowableDiagnostic/Aws/SnsDecorator.php
@@ -17,7 +17,10 @@ final class SnsDecorator implements SnsDecoratorInterface
     public function diagnose(Throwable $throwable): ThrowableDiagnosticInterface
     {
         if ($throwable instanceof SnsException) {
-            $transient = $this->isAwsErrorCodeTransient($throwable->getAwsErrorCode());
+            $transient = $throwable->isConnectionError();
+            if (!$transient && $throwable->getAwsErrorCode()) {
+                $transient = $this->isAwsErrorCodeTransient($throwable->getAwsErrorCode());
+            }
             throw $this->getDiagnosedFactory()
                 ->create()
                 ->setTransient($transient)

--- a/src/ThrowableDiagnostic/Aws/SqsDecorator.php
+++ b/src/ThrowableDiagnostic/Aws/SqsDecorator.php
@@ -17,7 +17,10 @@ final class SqsDecorator implements SqsDecoratorInterface
     public function diagnose(Throwable $throwable): ThrowableDiagnosticInterface
     {
         if ($throwable instanceof SqsException) {
-            $transient = $this->isAwsErrorCodeTransient($throwable->getAwsErrorCode());
+            $transient = $throwable->isConnectionError();
+            if (!$transient && $throwable->getAwsErrorCode()) {
+                $transient = $this->isAwsErrorCodeTransient($throwable->getAwsErrorCode());
+            }
             throw $this->getDiagnosedFactory()
                 ->create()
                 ->setTransient($transient)


### PR DESCRIPTION
While doing some manual testing I found out that `$throwable->getAwsErrorCode()` can return null.
I also noticed that there is a `isConnectionError()` method. This will also be set if the queue url doesn't resolve, so it might be non-transient. The AwsException has a previous exception, which is Guzzle HTTP. If we had a decorator for it, we could examine it further...