### PR TITLE
Symfony HTTP Client decorator considers 503 response codes transient.

### DIFF
--- a/src/ThrowableDiagnostic/SymfonyHttpClientDecorator.php
+++ b/src/ThrowableDiagnostic/SymfonyHttpClientDecorator.php
@@ -5,6 +5,7 @@ namespace Neighborhoods\ThrowableDiagnosticComponent\ThrowableDiagnostic;
 
 use Neighborhoods\ThrowableDiagnosticComponent\Diagnosed;
 use Neighborhoods\ThrowableDiagnosticComponent\ThrowableDiagnosticInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Throwable;
 
@@ -15,6 +16,15 @@ final class SymfonyHttpClientDecorator implements SymfonyHttpClientDecoratorInte
 
     public function diagnose(Throwable $throwable): ThrowableDiagnosticInterface
     {
+        // Server error 503 means service is temporarily unavailable.
+        if ($throwable instanceof ServerExceptionInterface) {
+            if ($throwable->getResponse()->getStatusCode() === 503) {
+                throw $this->getDiagnosedFactory()
+                    ->create()
+                    ->setTransient(true)
+                    ->setPrevious($throwable);
+            }
+        }
         if ($throwable instanceof TransportExceptionInterface) {
             throw $this->getDiagnosedFactory()
                 ->create()

--- a/test/Decorator/SymfonyHttpClientDecoratorTest.php
+++ b/test/Decorator/SymfonyHttpClientDecoratorTest.php
@@ -11,6 +11,7 @@ use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\TimeoutExceptionInterface;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 use Throwable;
 
 class SymfonyHttpClientDecoratorTest extends DecoratorTestCase
@@ -67,11 +68,36 @@ class SymfonyHttpClientDecoratorTest extends DecoratorTestCase
         $this->decorator->diagnose($analysedThrowable);
     }
 
-    public function testServerExceptionInterface()
+    public function test500ServerExceptionInterface()
     {
+        // Compose exception response
+        $mockedResponse = $this->createMock(ResponseInterface::class);
+        $mockedResponse->expects(self::atLeastOnce())
+            ->method('getStatusCode')
+            ->willReturn(500);
         $analysedThrowable = $this->createMock(ServerExceptionInterface::class);
+        $analysedThrowable->expects(self::atLeastOnce())
+            ->method('getResponse')
+            ->willReturn($mockedResponse);
         $this->expectForwarding($analysedThrowable);
         $this->expectNoDiagnosedCreation();
+        $this->decorator->diagnose($analysedThrowable);
+    }
+
+    public function test503ServerExceptionInterface()
+    {
+        // Compose exception response
+        $mockedResponse = $this->createMock(ResponseInterface::class);
+        $mockedResponse->expects(self::atLeastOnce())
+            ->method('getStatusCode')
+            ->willReturn(503);
+        $analysedThrowable = $this->createMock(ServerExceptionInterface::class);
+        $analysedThrowable->expects(self::atLeastOnce())
+            ->method('getResponse')
+            ->willReturn($mockedResponse);
+        $this->expectNoForwarding();
+        $diagnosed = $this->expectDiagnosedCreation($analysedThrowable, true);
+        $this->expectExceptionObject($diagnosed);
         $this->decorator->diagnose($analysedThrowable);
     }
 


### PR DESCRIPTION
In addition to Transport exception a Server exception with status code 503 in the response is considered transient as well.