### PR TITLE
429 HTTP status code

### DIFF
--- a/src/ThrowableDiagnostic/GuzzleDecorator.php
+++ b/src/ThrowableDiagnostic/GuzzleDecorator.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Neighborhoods\ThrowableDiagnosticComponent\ThrowableDiagnostic;
 
+use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Exception\ServerException;
@@ -32,6 +33,12 @@ final class GuzzleDecorator implements GuzzleDecoratorInterface
         // Server error 503 means service is temporarily unavailable.
         if ($throwable instanceof ServerException) {
             if ($throwable->getResponse()->getStatusCode() === 503) {
+                $isTransient = true;
+            }
+        }
+        // Client error 429 means too many requests.
+        if ($throwable instanceof ClientException) {
+            if ($throwable->getResponse()->getStatusCode() === 429) {
                 $isTransient = true;
             }
         }

--- a/src/ThrowableDiagnostic/Psr18Decorator.php
+++ b/src/ThrowableDiagnostic/Psr18Decorator.php
@@ -15,7 +15,8 @@ final class Psr18Decorator implements Psr18DecoratorInterface
 
     public function diagnose(Throwable $throwable): ThrowableDiagnosticInterface
     {
-        if ($throwable instanceof NetworkExceptionInterface) {
+        $transient = $throwable instanceof NetworkExceptionInterface;
+        if ($transient) {
             throw $this->getDiagnosedFactory()
                 ->create()
                 ->setTransient(true)

--- a/test/Decorator/GuzzleDecoratorTest.php
+++ b/test/Decorator/GuzzleDecoratorTest.php
@@ -25,11 +25,36 @@ class GuzzleDecoratorTest extends DecoratorTestCase
             ->setThrowableDiagnostic($this->getThrowableDiagnosticMock());
     }
 
-    public function testClientException()
+    public function test422ClientException()
     {
+        // Compose exception response
+        $mockedResponse = $this->createMock(ResponseInterface::class);
+        $mockedResponse->expects(self::atLeastOnce())
+            ->method('getStatusCode')
+            ->willReturn(422);
         $analysedThrowable = $this->createMock(ClientException::class);
+        $analysedThrowable->expects(self::atLeastOnce())
+            ->method('getResponse')
+            ->willReturn($mockedResponse);
         $this->expectForwarding($analysedThrowable);
         $this->expectNoDiagnosedCreation();
+        $this->decorator->diagnose($analysedThrowable);
+    }
+
+    public function test429ClientException()
+    {
+        // Compose exception response
+        $mockedResponse = $this->createMock(ResponseInterface::class);
+        $mockedResponse->expects(self::atLeastOnce())
+            ->method('getStatusCode')
+            ->willReturn(429);
+        $analysedThrowable = $this->createMock(ClientException::class);
+        $analysedThrowable->expects(self::atLeastOnce())
+            ->method('getResponse')
+            ->willReturn($mockedResponse);
+        $this->expectNoForwarding();
+        $diagnosed = $this->expectDiagnosedCreation($analysedThrowable, true);
+        $this->expectExceptionObject($diagnosed);
         $this->decorator->diagnose($analysedThrowable);
     }
 

--- a/test/Decorator/SymfonyHttpClientDecoratorTest.php
+++ b/test/Decorator/SymfonyHttpClientDecoratorTest.php
@@ -28,11 +28,36 @@ class SymfonyHttpClientDecoratorTest extends DecoratorTestCase
             ->setThrowableDiagnostic($this->getThrowableDiagnosticMock());
     }
 
-    public function testClientExceptionInterface()
+    public function test422ClientExceptionInterface()
     {
+        // Compose exception response
+        $mockedResponse = $this->createMock(ResponseInterface::class);
+        $mockedResponse->expects(self::atLeastOnce())
+            ->method('getStatusCode')
+            ->willReturn(422);
         $analysedThrowable = $this->createMock(ClientExceptionInterface::class);
+        $analysedThrowable->expects(self::atLeastOnce())
+            ->method('getResponse')
+            ->willReturn($mockedResponse);
         $this->expectForwarding($analysedThrowable);
         $this->expectNoDiagnosedCreation();
+        $this->decorator->diagnose($analysedThrowable);
+    }
+
+    public function test429ClientExceptionInterface()
+    {
+        // Compose exception response
+        $mockedResponse = $this->createMock(ResponseInterface::class);
+        $mockedResponse->expects(self::atLeastOnce())
+            ->method('getStatusCode')
+            ->willReturn(429);
+        $analysedThrowable = $this->createMock(ClientExceptionInterface::class);
+        $analysedThrowable->expects(self::atLeastOnce())
+            ->method('getResponse')
+            ->willReturn($mockedResponse);
+        $this->expectNoForwarding();
+        $diagnosed = $this->expectDiagnosedCreation($analysedThrowable, true);
+        $this->expectExceptionObject($diagnosed);
         $this->decorator->diagnose($analysedThrowable);
     }
 


### PR DESCRIPTION
Fixes #5.
429 status codes are considered transient.