### PR TITLE
Considering credential retrieval timeout in AWS decorator.

### DIFF
--- a/test/Decorator/Aws/DecoratorTest.php
+++ b/test/Decorator/Aws/DecoratorTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Neighborhoods\ThrowableDiagnosticComponentTest\Decorator\Aws;
+
+use Aws\Exception\CredentialsException;
+use Neighborhoods\ThrowableDiagnosticComponent\ThrowableDiagnostic\Aws\Decorator;
+use Neighborhoods\ThrowableDiagnosticComponentTest\Decorator\DecoratorTestCase;
+use Throwable;
+
+class DecoratorTest extends DecoratorTestCase
+{
+    protected $decorator;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->decorator = new Decorator();
+        $this->decorator
+            ->setDiagnosedFactory($this->getDiagnosedFactoryMock())
+            ->setThrowableDiagnostic($this->getThrowableDiagnosticMock());
+    }
+
+    public function testDiagnoseThrowsTransientDiagnosedForCredentialTimeout()
+    {
+        $credentialsTimeoutException = new CredentialsException("Error retrieving credentials from the instance profile metadata service. (cURL error 28: Operation timed out after 1001 milliseconds with 0 bytes received (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for http://169.254.169.254/latest/meta-data/iam/security-credentials/nhds-huddle-service-prod)");
+        $this->expectNoForwarding();
+        $diagnosed = $this->expectDiagnosedCreation($credentialsTimeoutException, true);
+        $this->expectExceptionObject($diagnosed);
+        $this->decorator->diagnose($credentialsTimeoutException);
+    }
+
+    public function testForwardsDummyThrowable()
+    {
+        $analysedThrowable = $this->createMock(Throwable::class);
+        $this->expectForwarding($analysedThrowable);
+        $this->expectNoDiagnosedCreation();
+        $this->decorator->diagnose($analysedThrowable);
+    }
+}


### PR DESCRIPTION
I want the AWS decorator to consider this exception https://logs.neighborhoods.com/app/kibana#/doc/357666f0-d59b-11e9-9ffa-d16e726260e2/prod-services-huddle-service-2021.01.20/fluentd?id=TX0TH3cBDK2soN77cFuQ&_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:now-24h,mode:quick,to:now)) as transient.