### PR TITLE
Considering all AWS failed credential retrievals transient

### DIFF
--- a/src/ThrowableDiagnostic/Aws/Decorator.php
+++ b/src/ThrowableDiagnostic/Aws/Decorator.php
@@ -21,7 +21,7 @@ final class Decorator implements DecoratorInterface
         if ($throwable instanceof CredentialsException) {
             // Check if retrieving credentials timed out
             // by checking if message has a specific start
-            if (strpos($throwable->getMessage(), "Error retrieving credentials from the instance profile metadata service. (cURL error 28: Operation timed out") === 0) {
+            if (strpos($throwable->getMessage(), "Error retrieving credentials from the instance profile metadata service.") === 0) {
                 throw $this->getDiagnosedFactory()
                     ->create()
                     ->setTransient(true)


### PR DESCRIPTION
In addition to the [timeout](https://logs.neighborhoods.com/app/kibana#/doc/357666f0-d59b-11e9-9ffa-d16e726260e2/prod-services-huddle-service-2021.02.09/fluentd?id=4qdkiHcBtZOzt3O_nMG-&_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:now-24h,mode:quick,to:now))) we also get the 'Error retrieving credentials from the instance profile metadata service.' when there is an issue with the [metadata token](https://logs.neighborhoods.com/app/kibana#/doc/8fadd770-d4d8-11e9-9ffa-d16e726260e2/dev-services-huddle-service-2021.02.09/fluentd?id=lCnRhncBtZOzt3O_Yef7&_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:now-24h,mode:quick,to:now))).
This change will handle all failed credential retrievals as transient.
Defending against the timeout has already proven to work. There is a job in huddle service production which experienced it, but succeeded after retrying. This happens rarely, but it does happen.