### PR TITLE
Removed service definitions which should never be used

### DIFF
--- a/fab/ThrowableDiagnosticV1/ThrowableDiagnostic/Builder.service.yml
+++ b/fab/ThrowableDiagnosticV1/ThrowableDiagnostic/Builder.service.yml
@@ -1,7 +1,0 @@
-services:
-  Neighborhoods\ThrowableDiagnosticComponent\ThrowableDiagnosticV1\ThrowableDiagnostic\BuilderInterface:
-    class: Neighborhoods\ThrowableDiagnosticComponent\ThrowableDiagnosticV1\ThrowableDiagnostic\Builder
-    public: false
-    shared: false
-    calls:
-      - [setThrowableDiagnosticV1ThrowableDiagnosticFactory, ['@Neighborhoods\ThrowableDiagnosticComponent\ThrowableDiagnosticV1\ThrowableDiagnostic\FactoryInterface']]

--- a/fab/ThrowableDiagnosticV1/ThrowableDiagnostic/Builder/Factory.service.yml
+++ b/fab/ThrowableDiagnosticV1/ThrowableDiagnostic/Builder/Factory.service.yml
@@ -1,7 +1,0 @@
-services:
-  Neighborhoods\ThrowableDiagnosticComponent\ThrowableDiagnosticV1\ThrowableDiagnostic\Builder\FactoryInterface:
-    class: Neighborhoods\ThrowableDiagnosticComponent\ThrowableDiagnosticV1\ThrowableDiagnostic\Builder\Factory
-    public: false
-    shared: true
-    calls:
-      - [setThrowableDiagnosticV1ThrowableDiagnosticBuilder, ['@Neighborhoods\ThrowableDiagnosticComponent\ThrowableDiagnosticV1\ThrowableDiagnostic\BuilderInterface']]

--- a/src/ThrowableDiagnosticV1/ThrowableDiagnostic.buphalo.v1.fabrication.yml
+++ b/src/ThrowableDiagnosticV1/ThrowableDiagnostic.buphalo.v1.fabrication.yml
@@ -17,14 +17,10 @@ actors:
     template: PrimaryActorName/Factory/AwareTrait.php
   <PrimaryActorName>/Builder.php:
     template: PrimaryActorName/Builder.php
-  <PrimaryActorName>/Builder.service.yml:
-    template: PrimaryActorName/Builder.service.yml
   <PrimaryActorName>/BuilderInterface.php:
     template: PrimaryActorName/BuilderInterface.php
   <PrimaryActorName>/Builder/AwareTrait.php:
     template: PrimaryActorName/Builder/AwareTrait.php
-  <PrimaryActorName>/Builder/Factory.service.yml:
-    template: PrimaryActorName/Builder/Factory.service.yml
   <PrimaryActorName>/Builder/Factory.php:
     template: PrimaryActorName/Builder/Factory.php
   <PrimaryActorName>/Builder/FactoryInterface.php:

--- a/template-tree/BuphaloV1/ThrowableDiagnosticComponent/ThrowableDiagnosticV1/DiagnoserV1/PrimaryActorName/ThrowableDiagnostic/Builder.service.yml
+++ b/template-tree/BuphaloV1/ThrowableDiagnosticComponent/ThrowableDiagnosticV1/DiagnoserV1/PrimaryActorName/ThrowableDiagnostic/Builder.service.yml
@@ -6,7 +6,7 @@ services:
     calls:
       - [setThrowableDiagnosticV1ThrowableDiagnosticFactory, ['@Neighborhoods\ThrowableDiagnosticComponent\ThrowableDiagnosticV1\ThrowableDiagnostic\FactoryInterface']]
       # Add predefined decorator(s) as shown below
-      #- [addFactory, ['@Neighborhoods\ThrowableDiagnosticComponent\ThrowableDiagnosticV1\ThrowableDiagnostic\<__TODO__>Decorator\FactoryInterface']]
+      #- [addFactory, ['@Neighborhoods\ThrowableDiagnosticComponent\ThrowableDiagnosticV1Decorators\DecoratorNameVX\<__TODO__>Decorator\FactoryInterface']]
 
       # Uncomment next line if you have a custom decorator.
       #- [addFactory, ['@Neighborhoods\BuphaloTemplateTree\PrimaryActorName\ThrowableDiagnostic\Decorator\FactoryInterface']]


### PR DESCRIPTION
I've seen aPR where a developer inject the unconfigured service definition of a throwable diagnostic builder factory.
This will hopefully prevent that in the future.

I've also update a template comment to point to the right subfolder.